### PR TITLE
Support for subsets, not ignoring woff2 font files, clearer fontBaseDir semantics, preventing multiple downloads

### DIFF
--- a/tasks/index.js
+++ b/tasks/index.js
@@ -85,7 +85,7 @@ module.exports = function (grunt) {
     destination += '/font_' + name.replace(/'/g, '').toLowerCase();
     destination += '_' + key + '.css';
 
-    grunt.file.write(destination, cleanCSS(body));
+    grunt.file.write(destination, body);
     done();
   }
 

--- a/tasks/index.js
+++ b/tasks/index.js
@@ -33,10 +33,10 @@ module.exports = function (grunt) {
 
           var url = getDownloadUrl(rule.declarations.src);
           if (url) {
-            var filename = options.fontDestination + '/' + getFilename(rule, key, url);
+            var filename = getFilename(rule, key, url);
 
             body = formatBody(options, body, url, filename);
-            downloadFont(url, filename, next);
+            downloadFont(url, options.fontDestination + '/' + filename, next);
           } else {
             next();
           }
@@ -58,7 +58,7 @@ module.exports = function (grunt) {
   function formatBody (options, body, url, filename) {
 
     if (options.fontBaseDir) {
-      filename = filename.replace(options.fontBaseDir + '/', '');
+      filename = options.fontBaseDir + '/' + encodeURIComponent(filename);
     }
 
     body = body.replace(url, '\'' + filename + '\'');

--- a/tasks/index.js
+++ b/tasks/index.js
@@ -52,7 +52,7 @@ module.exports = function (grunt) {
   }
 
   function cleanCSS (css) {
-    return css.replace(/unicode-range\:(\s|\w|\d|\+|-|,)*;/g, '');
+    return css.replace(/unicode-range\:.*?;/g, '');
   }
 
   function formatBody (options, body, url, filename) {

--- a/tasks/index.js
+++ b/tasks/index.js
@@ -98,17 +98,24 @@ module.exports = function (grunt) {
     var destFolder = parts.join('/');
     mkdirp.sync(destFolder);
 
-    var file = fs.createWriteStream(destination);
-    var remote = request(source);
+    fs.exists(destination, function(exists) {
+      if (exists) {
+        grunt.log.writeln('Already exists');
+        done();
+        return;
+      }
+      var file = fs.createWriteStream(destination);
+      var remote = request(source);
 
-    remote.on('data', function (chunk) {
-      file.write(chunk);
-    });
+      remote.on('data', function (chunk) {
+        file.write(chunk);
+      });
 
-    remote.on('end', function () {
-      grunt.log.ok();
-      file.end();
-      done();
+      remote.on('end', function () {
+        grunt.log.ok();
+        file.end();
+        done();
+      });
     });
   }
 

--- a/tasks/index.js
+++ b/tasks/index.js
@@ -62,17 +62,7 @@ module.exports = function (grunt) {
     }
 
     body = body.replace(url, '\'' + filename + '\'');
-
-    var included = [];
-    var parts = body.split(',');
-
-    parts.forEach(function (part) {
-      if (part.indexOf('woff2') < 0) {
-        included.push(part);
-      }
-    });
-
-    return included.join(',');
+    return body;
   }
 
   function writeStylesheet (options, key, body, rules, done) {
@@ -139,9 +129,6 @@ module.exports = function (grunt) {
     var match = matches && matches[1];
 
     if (!match) return '';
-
-    if (match.indexOf('woff2') > 0)
-      return getDownloadUrl(string.replace(match, ''));
 
     return match;
   }

--- a/tasks/index.js
+++ b/tasks/index.js
@@ -146,9 +146,9 @@ module.exports = function (grunt) {
     return match;
   }
 
-  function getPublicUrl (family, sizes) {
+  function getPublicUrl (family, sizes, subsets) {
 
-    return 'http://fonts.googleapis.com/css?family=' + family + ':' + sizes.join(',');
+    return 'http://fonts.googleapis.com/css?family=' + family + ':' + sizes.join(',') + (subsets && subsets.length ? '&subset=' + subsets.join(',') : '');
   }
 
   var downloadFontsTask = function downloadFontsForUrl () {
@@ -163,7 +163,7 @@ module.exports = function (grunt) {
       grunt.fail.fatal('Invalid font size(s) declaration');
     }
 
-    var url = getPublicUrl(options.family, options.sizes);
+    var url = getPublicUrl(options.family, options.sizes, options.subsets);
 
     if (!options.userAgents) {
       options.userAgents = {

--- a/tasks/index.js
+++ b/tasks/index.js
@@ -83,7 +83,7 @@ module.exports = function (grunt) {
     mkdirp.sync(destination);
 
     destination += '/font_' + name.replace(/'/g, '').toLowerCase();
-    destination += '_' + key + '.styl';
+    destination += '_' + key + '.css';
 
     grunt.file.write(destination, cleanCSS(body));
     done();

--- a/tasks/index.js
+++ b/tasks/index.js
@@ -32,10 +32,14 @@ module.exports = function (grunt) {
         if (rule.type === 'fontface') {
 
           var url = getDownloadUrl(rule.declarations.src);
-          var filename = options.fontDestination + '/' + getFilename(rule, key, url);
+          if (url) {
+            var filename = options.fontDestination + '/' + getFilename(rule, key, url);
 
-          body = formatBody(options, body, url, filename);
-          downloadFont(url, filename, next);
+            body = formatBody(options, body, url, filename);
+            downloadFont(url, filename, next);
+          } else {
+            next();
+          }
         }
       }
 


### PR DESCRIPTION
Here are multiple changes I needed to do when trying to use this library. The font, I was trying to use locally, was: http://fonts.googleapis.com/css?family=Open%20Sans:400italic,700italic,400,600,700&subset=latin,latin-ext

Few notes:
- I do not know why you were handling `.woff2` fonts differently. I removed that because I needed the `.woff2` font. I hope this is fine.
- I changed the extension of the CSS file from `.styl` to `.css`. It is not clear to me, why it was set to `.styl`, because `.css` works better (syntax highlighting, all servers set correct content-type, etc.).
- I think, the function to clean the CSS was there mainly for parsing the CSS. I removed CSS cleaning when writing the CSS to the local file, because it is not necessary there (and the "cleaned" CSS was also not correct).
- I changed the logic of `fontBaseDir` option. It was used to specify a prefix that should be removed from the `fontDestination + '/' + filename` in the CSS file. Now it is used to specify a prefix that should be added before the `filename`. That was needed for my case, when the relative path from CSS to the font file was `../fonts/font.woff2` - it could not be achieved without this change. I also think it is now more simple to use.

Best regards,
PePri
